### PR TITLE
Specify minimum numpy version directly

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setup(
     package_dir={'':'src'},
     ext_modules=cythonize([extension,extension2,extension3,extension4]),
     classifiers=['Development Status :: 4 - Beta'],
-    install_requires=["tqdm","scipy",f"numpy=={numpy.__version__}"],
+    install_requires=["tqdm","scipy","numpy>=1.19.0"],
     include_package_data=True,
     zip_safe=False
 )


### PR DESCRIPTION
This PR fixes an issue where the required numpy version is (apparently) pinned to the latest when fetched, but which may be incompatible with packages installed later.

The following `requirements.txt` fails with a dependency conflict for numpy when installed into a fresh virtual environment. 
```
git+https://github.com/quantumgizmos/ldpc@67b33fe#ldpc
galois==0.0.30
```

Yields
```bash
The conflict is caused by:
    ldpc 0.1.4 depends on numpy==1.23.1
    galois 0.0.30 depends on numpy<1.23 and >=1.18.4
```

However, the `pyproject.toml` only requires `numpy>=1.19.0`. Ideally there would be only one source of truth here, but I am not very familiar with the python package building sequence.
