### PR TITLE
Modernize packaging

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,6 @@ on:
       - release
 
 jobs:
-
   build_wheels:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -15,30 +14,39 @@ jobs:
         os: [ubuntu-latest,windows-latest,macos-latest]
 
     steps:
-      - uses: actions/checkout@v2
-
+      - uses: actions/checkout@v3
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.3.1
-        env:
-          CIBW_SKIP: '*musllinux* pp*'
-          CIBW_ARCHS_MACOS: x86_64 arm64
-      - uses: actions/upload-artifact@v2
+        uses: pypa/cibuildwheel@v2.12.1
+      - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl
 
-      - uses: actions/setup-python@v2
-        name: Install Python
+  build_sdist:
+    name: Build sdist
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
-          python-version: '3.7'
+          python-version: "3.8"
+      - name: Build sdist
+        run: pipx run build --sdist
+      - name: Install sdist
+        run: python -m pip install --verbose dist/*.tar.gz
+      - uses: actions/upload-artifact@v3
+        with:
+          path: dist/*.tar.gz
 
-      - name: Install twine
-        run: |
-          python -m pip install twine
-
-      - name: Build and publish
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-        run: |
-          twine upload ./wheelhouse/*
-
+  upload_pypi:
+    needs: [ build_wheels, build_sdist ]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: artifact
+          path: dist
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_PASSWORD }}
+          skip_existing: true
+          verbose: true

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,7 @@ include src/ldpc/README.md
 include src/ldpc/LICENSE
 include src/ldpc/VERSION
 include src/ldpc/*.pxd
+include src/ldpc/*.pyx
 include src/ldpc/include/*.h
 include src/ldpc/include/*.c
 include src/ldpc/include/COPYRIGHT

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,33 @@
 [build-system]
-requires = ["cython","setuptools","wheel","numpy>=1.19.0"]
+requires = ["cython","setuptools>=61","numpy>=1.19.0"]
 build-backend = "setuptools.build_meta"
+
+[project]
+name = "ldpc"
+description = "Python tools for low density parity check (LDPC) codes"
+readme = "README.md"
+authors = [
+    { name = "Joschka Roffe", email = "joschka@roffe.eu" }
+]
+license = { file = "LICENSE" }
+
+classifiers = [
+    "Development Status :: 4 - Beta",
+]
+requires-python = ">=3.6"
+dependencies = [
+    "numpy>=1.19.0",
+    "scipy",
+    "tqdm",
+]
+dynamic = ["version"]
+
+[project.urls]
+Homepage = "https://github.com/quantumgizmos/ldpc"
+
+[tool.cibuildwheel]
+build = "cp3*"
+skip = "*-musllinux*"
+
+[tool.cibuildwheel.macos]
+archs = ["x86_64", "arm64"]

--- a/setup.py
+++ b/setup.py
@@ -1,20 +1,11 @@
 from setuptools import setup, Extension
-# from distutils.extension import Extension
 from Cython.Build import cythonize
 import numpy
-from pathlib import Path
-this_directory = Path(__file__).parent
-long_description = (this_directory / "README.md").read_text()
 
 VERSION="0.1.45"
 f=open("src/ldpc/VERSION","w+")
 f.write(VERSION)
 f.close()
-
-from shutil import copyfile
-files=["README.md","LICENSE"]
-for f in files:
-    copyfile(f,"src/ldpc/"+f)
 
 extension = Extension(
     name="ldpc.bp_decoder",
@@ -53,20 +44,6 @@ extension4 = Extension(
     )
 
 setup(
-    python_requires='>=3.6',
-    name='ldpc',
     version=VERSION,
-    description='Python tools for low density parity check (LDPC) codes',
-    long_description=long_description,
-    long_description_content_type='text/markdown',
-    url='https://github.com/quantumgizmos/ldpc',
-    author='Joschka Roffe',
-    packages=["ldpc"],
-    package_dir={'':'src'},
     ext_modules=cythonize([extension,extension2,extension3,extension4]),
-    classifiers=['Development Status :: 4 - Beta'],
-    install_requires=["tqdm","scipy","numpy>=1.19.0"],
-    include_package_data=True,
-    zip_safe=False
 )
-


### PR DESCRIPTION
Hey there 👋🏼 

While working on an extension to our tool for QECC (https://github.com/cda-tum/qecc), I noticed that this project is not providing wheels for Python 3.11 and doesn't provide an sdist to PyPI (the latter was already requested in #14).

This PR builds on the best practises for Python package we developed for the tools developed at our chair and improves the overall configuration of this project:

- It makes sure that all files required for building the project are included in the sdist
- It simplifies the packaging configuration by switching to PEP 621 for specifying project metadata (https://packaging.python.org/en/latest/specifications/declaring-project-metadata/#declaring-project-metadata).
- It updates cibuildwheel to the latest version, which enables building Python 3.11 wheels
- It adds a job to the CI workflow that builds, tests, and distributes the sdist for the project (fixes #14)
- It switches to the official PyPA publishing action
- It updates the versions of several general purpose GitHub Action

This should make your library more compatible and maintainable.