### PR TITLE
fix example

### DIFF
--- a/docs/source/bp_decoding_example.ipynb
+++ b/docs/source/bp_decoding_example.ipynb
@@ -223,7 +223,7 @@
     "    print(f\"Error: {error}\")\n",
     "    print(f\"Syndrome: {syndrome}\")\n",
     "    decoding=bpd.decode(syndrome)\n",
-    "    print(f\"Decoding: {error}\\n\")"
+    "    print(f\"Decoding: {decoding}\\n\")"
    ]
   }
  ],


### PR DESCRIPTION
display `decoding` instead of `error`