### PR TITLE
forbid numpy 2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
 ]
 requires-python = ">=3.8"
 dependencies = [
-    "numpy>=1.19.0",
+    "numpy>=1.19.0,<2",
     "scipy",
     "tqdm",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["cython","setuptools>=61","numpy>=1.19.0"]
+requires = ["cython","setuptools>=61","numpy>=1.19.0,<2"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
fixes #40 

This was necessary in order to make the julia package that wraps this (PyQDecoders.jl) to install once again.