### PR TITLE
🩹 fix invalid escape sequence

### DIFF
--- a/src/ldpc/mod2.py
+++ b/src/ldpc/mod2.py
@@ -249,7 +249,7 @@ def reduced_row_echelon(matrix):
     return [reduced_row_echelon_form, matrix_rank, transform_matrix_rows, transform_matrix_columns]
 
 def nullspace(matrix):
-    """
+    r"""
     Computes the nullspace of the matrix M. Also sometimes referred to as the kernel.
 
     All vectors x in the nullspace of M satisfy the following condition::


### PR DESCRIPTION
This tiny PR fixes a small issue with one of the docstrings in the package.
Without this change running `pytest` with `-Werror` enabled produces warnings of the sort:
```bash
E     File "/home/runner/work/mqt-qecc/mqt-qecc/.nox/tests-3-10/lib/python3.10/site-packages/ldpc/mod2.py", line 252
E       """
E       ^^^
E   SyntaxError: invalid escape sequence '\i'
```
See https://github.com/cda-tum/mqt-qecc/actions/runs/9759817624/job/26937308477?pr=216#step:10:710 for a real world example.

Note that these are actually just `SyntaxWarnings` that are "promoted" to errors by `-Werror`. The main cause is that the docstring in the offending function uses backslashes which are interpreted as escape sequences. However, sequences like `\I` are invalid and thus marked as an error.
The solution is simple: Just making the docstring a raw string literal avoids the error.

Local debugging over at the mqt-qecc repo has shown that this is enough to resolve the errors we are seeing.

I know you are currently in the process of a complete rewrite, but until that happens to be released, it would be great to have this merged and a new version released.

(The missing newline at the end is automatically inserted by GitHub. It's a good practice anyways)