### PR TITLE
fix Sinter decoders panic while decoding un-decomposable DEMs

### DIFF
--- a/src_python/ldpc/sinter_decoders/sinter_belief_find_decoder.py
+++ b/src_python/ldpc/sinter_decoders/sinter_belief_find_decoder.py
@@ -120,7 +120,9 @@ class SinterBeliefFindDecoder(sinter.Decoder):
                 via sinter deleting this directory after killing the decoder.
         """
         self.dem = stim.DetectorErrorModel.from_file(dem_path)
-        self.matrices = detector_error_model_to_check_matrices(self.dem)
+        self.matrices = detector_error_model_to_check_matrices(
+            self.dem, allow_undecomposed_hyperedges=True
+        )
         self.belief_find = BeliefFindDecoder(
             self.matrices.check_matrix,
             error_channel=list(self.matrices.priors),

--- a/src_python/ldpc/sinter_decoders/sinter_bposd_decoder.py
+++ b/src_python/ldpc/sinter_decoders/sinter_bposd_decoder.py
@@ -95,7 +95,9 @@ class SinterBpOsdDecoder(sinter.Decoder):
                 via sinter deleting this directory after killing the decoder.
         """
         self.dem = stim.DetectorErrorModel.from_file(dem_path)
-        self.matrices = detector_error_model_to_check_matrices(self.dem)
+        self.matrices = detector_error_model_to_check_matrices(
+            self.dem, allow_undecomposed_hyperedges=True
+        )
         self.bposd = BpOsdDecoder(
             self.matrices.check_matrix,
             error_channel=list(self.matrices.priors),

--- a/src_python/ldpc/sinter_decoders/sinter_lsd_decoder.py
+++ b/src_python/ldpc/sinter_decoders/sinter_lsd_decoder.py
@@ -92,7 +92,9 @@ class SinterLsdDecoder(sinter.Decoder):
                 via sinter deleting this directory after killing the decoder.
         """
         self.dem = stim.DetectorErrorModel.from_file(dem_path)
-        self.matrices = detector_error_model_to_check_matrices(self.dem)
+        self.matrices = detector_error_model_to_check_matrices(
+            self.dem, allow_undecomposed_hyperedges=True
+        )
         self.lsd = BpLsdDecoder(
             self.matrices.check_matrix,
             error_channel=list(self.matrices.priors),


### PR DESCRIPTION
Since BPOSD, BPLSD and BPUF decoders don't really rely on the detector error model (DEM) being decomposable, it should not panic in such cases. Added `allow_undecomposed_hyperedges = True` to the function calls.
