### PR TITLE
Specify minimum `sinter` dep

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "tqdm",
     "pytest",
     "stim",
-    "sinter",
+    "sinter>=1.12.0",
     "pymatching"
 ]
 version = "2.3.4"


### PR DESCRIPTION
This simply pins the minimum required version of `sinter`.

As of `ldpc 2.2.0`, using `sinter<1.12` results in import errors. Mainly ```ImportError: cannot import name 'CompiledDecoder' from 'sinter'```