### PR TITLE
Fix docstring in `mod2_numpy.py`

### DIFF
--- a/src_python/ldpc/mod2/mod2_numpy.py
+++ b/src_python/ldpc/mod2/mod2_numpy.py
@@ -266,7 +266,7 @@ def reduced_row_echelon(matrix):
 
 
 def nullspace(matrix):
-    """
+    r"""
     Computes the nullspace of the matrix M. Also sometimes referred to as the kernel.
 
     All vectors x in the nullspace of M satisfy the following condition::
@@ -426,8 +426,8 @@ def inverse(matrix):
 
     else:
         raise ValueError(
-            "This matrix is not invertible. Please provide either a full-rank square\
-        matrix or a rectangular matrix with full column rank."
+            "This matrix is not invertible. Please provide either a full-rank square "
+            "matrix or a rectangular matrix with full column rank."
         )
 
 


### PR DESCRIPTION
This PR fixes the docstring of `nullspace()` in `mod2_numpy.py`. Currently, importing `mod2_numpy` can lead to the following error:

```
    from ldpc.mod2 import mod2_numpy
E     File "/Users/runner/work/qecc/qecc/.nox/tests-3-13/lib/python3.13/site-packages/ldpc/mod2/mod2_numpy.py", line 274
E       Mx=0 \forall x \in nullspace(M)
E                      ^^
E   SyntaxError: invalid escape sequence '\i'
```