### PR TITLE
Build Python 3.14 wheels

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,7 +99,7 @@ jobs:
       # Run cibuildwheel to build the wheels.
       # cibuildwheel creates wheels for the specified configurations in isolated environments.
       - name: Run cibuildwheel
-        uses: pypa/cibuildwheel@v3.1.1
+        uses: pypa/cibuildwheel@v3.2.1
 
       # Upload the built wheels as artifacts.
       # The artifact name includes the GitHub run ID and matrix configuration to uniquely identify the wheels.


### PR DESCRIPTION
This PR updates `build.yml` to build Python 3.14 wheels. 

Fixes #90 