### PR TITLE
Drop support for Python 3.9

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,25 +62,21 @@ jobs:
       matrix:
         os_dist: [
           # macOS wheels for CPython (x86_64)
-          {os: macos-latest, dist: cp39-macosx_x86_64},
           {os: macos-latest, dist: cp310-macosx_x86_64},
           {os: macos-latest, dist: cp311-macosx_x86_64},
           {os: macos-latest, dist: cp312-macosx_x86_64},
           {os: macos-latest, dist: cp313-macosx_x86_64},
           # macOS wheels for CPython (arm64)
-          {os: macos-latest, dist: cp39-macosx_arm64},
           {os: macos-latest, dist: cp310-macosx_arm64},
           {os: macos-latest, dist: cp311-macosx_arm64},
           {os: macos-latest, dist: cp312-macosx_arm64},
           {os: macos-latest, dist: cp313-macosx_arm64},
           # Windows wheels
-          {os: windows-latest, dist: cp39-win_amd64},
           {os: windows-latest, dist: cp310-win_amd64},
           {os: windows-latest, dist: cp311-win_amd64},
           {os: windows-latest, dist: cp312-win_amd64},
           {os: windows-latest, dist: cp313-win_amd64},
           # Ubuntu (Manylinux) wheels
-          {os: ubuntu-latest, dist: cp39-manylinux_x86_64},
           {os: ubuntu-latest, dist: cp310-manylinux_x86_64},
           {os: ubuntu-latest, dist: cp311-manylinux_x86_64},
           {os: ubuntu-latest, dist: cp312-manylinux_x86_64},

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The documentation for `LDPCv2` can be found [here](https://roffe.eu/software/ldp
 
 ## Installation
 
-The easiest way to install the package is via pip. Python versions `>=3.9` are supported.
+The easiest way to install the package is via pip. Python versions `>=3.10` are supported.
 
 ```pip install -U ldpc```
 
@@ -19,7 +19,7 @@ The C++ source code can be found in src_cpp. Python bindings are implemented usi
 
 - Download the repo.
 - Navigate to the root.
-- Pip install with `python>=3.8`.
+- Pip install with `python>=3.10`.
 Note: installation requires a `C` compiler. Eg. `gcc` on Linux or `clang` on Windows.
 
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ license = { file = "LICENSE" }
 classifiers = [
     "Development Status :: 4 - Beta",
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "numpy>=1.24.0",
     "scipy>=1.9.3",


### PR DESCRIPTION
As the version has reached its scheduled end of life, this PR drops support for Python 3.9. `build.yml` is updated accordingly.

Fixes #95