### PR TITLE
Discrepancy in BpOsd decoder `default_method` between Python bindings docs and underlying C++ implementation

### DIFF
--- a/src_cpp/bp.hpp
+++ b/src_cpp/bp.hpp
@@ -78,7 +78,7 @@ namespace ldpc {
                     BpSparse &parity_check_matrix,
                     std::vector<double> channel_probabilities,
                     int maximum_iterations = 0,
-                    BpMethod bp_method = PRODUCT_SUM,
+                    BpMethod bp_method = MINIMUM_SUM,
                     BpSchedule schedule = PARALLEL,
                     double min_sum_scaling_factor = 0.625,
                     int omp_threads = 1,


### PR DESCRIPTION
closes #99 

## Description

There appears to be a mismatch between the Python bindings documentation and the actual behaviour in the underlying C++ code for the `BpOsd` decoder.

In the Python stub (`src_python/ldpc/bp_decoder/__init__.pyi`, line 408), the `__cinit__` method is depicted as:

```python
def __cinit__(self, pcm: Union[np.ndarray, spmatrix], error_rate: Optional[float] = None,
             error_channel: Optional[List[float]] = None, max_iter: Optional[int] = 0, bp_method: Optional[str] = 'minimum_sum',
             ms_scaling_factor: Optional[float] = 1.0, cutoff: Optional[float] = np.inf, sigma: float = 2.0, **kwargs): ...
```
However, it seems that the actual C++ implementation is still using `product_sum` as the default (`src_cpp/bp.hpp`, line 77)

```c++
BpDecoder(
        BpSparse &parity_check_matrix,
        std::vector<double> channel_probabilities,
        int maximum_iterations = 0,
        BpMethod bp_method = PRODUCT_SUM,
        ...
```

## Changes

Assuming the documentation reflects the intended use, these changes change the default value for `bp_method` for the BPDecoder class in `src_cpp/bp.hpp`.

